### PR TITLE
Links must be absolute for other domains

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Get the gem from [RubyGems](https://rubygems.org/gems/patreon)
 
 Step 1. Get your client_id and client_secret
 ---
-Visit the [OAuth Documentation Page](http://patreon.com/oauth2/documentation)
+Visit the [OAuth Documentation Page](https://patreon.com/oauth2/documentation)
 while logged in as a Patreon creator to register your client.
 
 This will provide you with a `client_id` and a `client_secret`.

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ Get the gem from [RubyGems](https://rubygems.org/gems/patreon)
 
 Step 1. Get your client_id and client_secret
 ---
-Visit the [OAuth Documentation Page](patreon.com/oauth2/documentation)
+Visit the [OAuth Documentation Page](http://patreon.com/oauth2/documentation)
 while logged in as a Patreon creator to register your client.
 
 This will provide you with a `client_id` and a `client_secret`.


### PR DESCRIPTION
Clicking the 'OAuth Documentation Page' link now, in this repository, takes you to a 404 page, because the resulting link is https://github.com/Patreon/patreon-ruby/blob/master/patreon.com/oauth2/documentation

Adding a top level http:// is required in order to send the user to Patreon's site.