### PR TITLE
Add a user-agent string to requests for correct platform attribution

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,7 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   Copyright 2015-2016 Patreon, Inc.
+   Copyright 2015-2018 Patreon, Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.

--- a/NOTICE
+++ b/NOTICE
@@ -1,4 +1,4 @@
 Patreon Integration for Ruby
-Copyright 2015-2016 Patreon, Inc.
+Copyright 2015-2018 Patreon, Inc.
 
 This product includes software developed at Patreon, Inc. (https://www.patreon.com/).

--- a/example/fetch_all_patrons.rb
+++ b/example/fetch_all_patrons.rb
@@ -1,4 +1,4 @@
-require_relative 'lib/patreon'
+require_relative '../lib/patreon'
 require 'uri'
 require 'cgi'
 

--- a/lib/patreon.rb
+++ b/lib/patreon.rb
@@ -2,6 +2,8 @@ $: << File.dirname(__FILE__)
 
 require 'patreon/utils/jsonapi/url_util'
 require 'patreon/utils/enum'
+require 'patreon/utils/client'
+require 'patreon/version'
 require 'patreon/schemas'
 require 'patreon/oauth'
 require 'patreon/api'

--- a/lib/patreon/api.rb
+++ b/lib/patreon/api.rb
@@ -33,16 +33,17 @@ module Patreon
     private
 
     def get_json(suffix)
-      http = Net::HTTP.new("api.patreon.com", 443)
+      http = Net::HTTP.new("www.patreon.com", 443)
       http.use_ssl = true
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       #SECURITY HOLE
       http.set_debug_output($stdout) if ENV['DEBUG']
 
-      url = URI.parse("https://api.patreon.com/oauth2/api/#{suffix}")
+      url = URI.parse("https://www.patreon.com/api/oauth2/api/#{suffix}")
       req = Net::HTTP::Get.new(url.to_s)
       req['Authorization'] = "Bearer #{@access_token}"
+      req['User-Agent'] = Utils::Client.user_agent_string
       res = http.request(req)
       return JSON::Api::Vanilla.parse(res.body)
     end

--- a/lib/patreon/api.rb
+++ b/lib/patreon/api.rb
@@ -35,13 +35,14 @@ module Patreon
     def get_json(suffix)
       http = Net::HTTP.new("www.patreon.com", 443)
       http.use_ssl = true
+
+      # TODO: It would be nice if we verified our certs
       http.verify_mode = OpenSSL::SSL::VERIFY_NONE
 
       #SECURITY HOLE
       http.set_debug_output($stdout) if ENV['DEBUG']
 
-      url = URI.parse("https://www.patreon.com/api/oauth2/api/#{suffix}")
-      req = Net::HTTP::Get.new(url.to_s)
+      req = Net::HTTP::Get.new("/api/oauth2/api/#{suffix}")
       req['Authorization'] = "Bearer #{@access_token}"
       req['User-Agent'] = Utils::Client.user_agent_string
       res = http.request(req)

--- a/lib/patreon/oauth.rb
+++ b/lib/patreon/oauth.rb
@@ -30,9 +30,10 @@ module Patreon
     private
 
     def update_token(params)
-      url = URI.parse('https://api.patreon.com/oauth2/token')
+      url = URI.parse('https://www.patreon.com/api/oauth2/token')
       url.query = URI.encode_www_form(params)
       req = Net::HTTP::Post.new(url.to_s)
+      req['User-Agent'] = Utils::Client.user_agent_string
       res = Net::HTTP.start(url.host, url.port, :use_ssl => true) {|http| http.request(req)}
       JSON.parse(res.body)
     end

--- a/lib/patreon/utils/client.rb
+++ b/lib/patreon/utils/client.rb
@@ -1,0 +1,11 @@
+require 'rbconfig'
+
+module Patreon
+	module Utils
+		module Client
+			def self.user_agent_string
+				"Patreon-Ruby, version #{Patreon::VERSION}, platform #{RbConfig::CONFIG['host']}"
+			end
+		end
+	end
+end

--- a/lib/patreon/utils/client.rb
+++ b/lib/patreon/utils/client.rb
@@ -1,11 +1,11 @@
 require 'rbconfig'
 
 module Patreon
-	module Utils
-		module Client
-			def self.user_agent_string
-				"Patreon-Ruby, version #{Patreon::VERSION}, platform #{RbConfig::CONFIG['host']}"
-			end
-		end
-	end
+  module Utils
+    module Client
+      def self.user_agent_string
+        "Patreon-Ruby, version #{Patreon::VERSION}, platform #{RbConfig::CONFIG['host']}"
+      end
+    end
+  end
 end


### PR DESCRIPTION
Github is rendering some of this weirdly, but this was tested by running the `fetch_all_patrons.rb` script in the example directory.