### PR TITLE
Update example and link to its README from top level README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,10 @@ while logged in as a Patreon creator to register your client.
 This will provide you with a `client_id` and a `client_secret`.
 
 Step 2. Use this library
+
+e.g. [the example Sinatra app in this repo](example/sinatra/README.md) or the Rails route example below.
+
 ---
-e.g., in a Rails route
 ```ruby
 require 'patreon'
 

--- a/example/sinatra/models/manager/patreon_user_mgr.rb
+++ b/example/sinatra/models/manager/patreon_user_mgr.rb
@@ -12,25 +12,27 @@ class PatreonUserManager
 
     # Get the patron's profile info and pledge amount
     user_response = api_client.fetch_user()
-    patreon_user_data = user_response['data']
+    patreon_user_data = user_response.data
     return nil unless patreon_user_data
 
     # Find or make the user, and set their information using the API response
-    db_user = User.first_or_create({:patreon_user_id => patreon_user_data['id']})
+    db_user = User.first_or_create({:patreon_user_id => patreon_user_data.id})
     db_user.update({
-      :full_name => patreon_user_data['attributes']['full_name'],
-      :email => patreon_user_data['attributes']['email'],
+      :full_name => patreon_user_data.full_name,
+      :email => patreon_user_data.email,
       :patreon_refresh_token => patreon_refresh_token,
       :patreon_access_token => patreon_access_token
     })
 
     # Find the user's pledge to us, and if they have one, update their pledge amount in our db
-    pledge = (user_response['included'] || []).find {|obj|
-      obj['type'] == 'pledge' and obj['relationships']['creator']['data']['id'] == MyConfig::PATREON_CREATOR_ID
+    # puts user_response.data.methods
+    pledges = (user_response.find_all('pledge') || [])
+    pledge = pledges.find {|obj|
+      obj.creator.id == MyConfig::PATREON_CREATOR_ID
     }
     if pledge
       db_user.update({
-          :patreon_pledge_amount_cents => pledge['attributes']['amount_cents']
+          :patreon_pledge_amount_cents => pledge.amount_cents
       })
     end
 


### PR DESCRIPTION
The example (that I didn't find at first because it wasn't mentioned in the top level README) had some errors since a recent change in what JSONapi object we return. Fixed those bugs and added a note to the README