### PR TITLE
Initialize Net::HTTP::Post with URI instead of string

### DIFF
--- a/lib/patreon/oauth.rb
+++ b/lib/patreon/oauth.rb
@@ -29,7 +29,7 @@ module Patreon
     def update_token(params)
       url = URI.parse('https://www.patreon.com/api/oauth2/token')
       url.query = URI.encode_www_form(params)
-      req = Net::HTTP::Post.new(url.to_s)
+      req = Net::HTTP::Post.new(url)
       req['User-Agent'] = Utils::Client.user_agent_string
       res = Net::HTTP.start(url.host, url.port, :use_ssl => true) {|http| http.request(req)}
       JSON.parse(res.body)


### PR DESCRIPTION
Initializing it with a string causes `path` to be incorrect:
```ruby
url = URI.parse('https://www.patreon.com/api/oauth2/token')
req = Net::HTTP::Post.new(url.to_s)
req.path
# => "https://www.patreon.com/api/oauth2/token"
```
As opposed to
```ruby
url = URI.parse('https://www.patreon.com/api/oauth2/token')
req = Net::HTTP::Post.new(url)
req.path
# => "/api/oauth2/token"
```

[ruby-doc](https://ruby-doc.org/stdlib-2.4.1/libdoc/net/http/rdoc/Net/HTTP.html#class-Net::HTTP-label-POST) for `Net::HTTP::Post` shows initialization using a `URI` too.

Initializing with a string causes apm-agent-ruby to raise with `URI::InvalidURIError`. Related issue: https://github.com/elastic/apm-agent-ruby/issues/834